### PR TITLE
Rework onboarding for custom sync codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# Pagina-calendario-custom
-una pagina que sea un calendario custom totalmente a el estilo que vos eligas 
+# Calendario Personalizado con IA
+
+Aplicación web que diseña un calendario temático según la descripción que ingresa
+la persona usuaria. El aspecto visual se genera en vivo con un motor heurístico
+que interpreta palabras clave y compone varias propuestas coherentes sin
+necesitar servicios externos.
+
+## Características principales
+
+- Formulario para describir cómo debería verse el calendario.
+- Motor de IA embebido que analiza colores, referencias y estados de ánimo
+  mencionados y devuelve entre 3 y 4 estilos listos para aplicar.
+- Paletas, tokens de diseño y explicaciones creadas dinámicamente para cada
+  propuesta.
+- Calendario navegable por meses que adopta al instante el estilo elegido.
+- Vista previa accesible con contraste ajustado automáticamente según el tema.
+- Identificación inicial que solicita tu nombre y el tipo de dispositivo para
+  adaptar la resolución y guardar tu experiencia.
+- Perfiles persistentes en `localStorage` con eventos, estilos elegidos y
+  opciones de sincronización entre dispositivos mediante un código seguro.
+
+## Cómo usar la aplicación
+
+1. Cloná el repositorio o descargá los archivos.
+2. Abrí `index.html` directamente en tu navegador o servilo de forma local con:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+   Después ingresá en `http://localhost:8000/index.html`.
+3. Indicá tu nombre, elegí si estás navegando desde un celular o una
+   computadora, definí el código personal con el que vas a volver a entrar y,
+   si ya exportaste un perfil, pegá el código completo para recuperarlo.
+4. Escribí qué estética buscás y hacé clic en **“Pedir sugerencias inteligentes”**.
+5. Explorá las propuestas sugeridas, elegí tu favorita y mirá cómo cambia el calendario.
+
+> El motor interpreta términos como "oscuro", "pastel", "elegante" o referencias
+> estacionales (Navidad, primavera, etc.) para adaptar las paletas, las tipografías
+> y el tipo de fondo sin depender de una conexión a internet adicional.
+
+## Perfiles y sincronización
+
+- El calendario se guarda automáticamente por nombre de usuario y código
+  personal. Podés volver en cualquier momento y retomar tus eventos y el estilo
+  aplicado.
+- El saludo superior muestra tu alias elegido y el código completo
+  (`alias::datos_codificados`) que debés copiar para continuar en otro navegador
+  o dispositivo. Pegalo en el campo "código guardado" de la pantalla inicial
+  para restaurar todo.
+- El selector de dispositivo fuerza la interfaz a un ancho móvil (420px) o de
+  escritorio (1200px) independientemente de la pantalla desde donde ingreses.

--- a/index.html
+++ b/index.html
@@ -164,7 +164,9 @@
               ▶
             </button>
           </div>
-          <div class="calendar-grid" role="grid"></div>
+          <div class="calendar-grid-wrapper">
+            <div class="calendar-grid" role="grid"></div>
+          </div>
         </div>
       </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calendario Personalizado con IA</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&family=Space+Grotesk:wght@400;600&family=Playfair+Display:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <section
+      id="session-screen"
+      class="session-screen"
+      aria-labelledby="session-title"
+    >
+      <form id="session-form" class="session-card" novalidate>
+        <h2 id="session-title">Empecemos por tu perfil</h2>
+        <p>
+          Contanos tu nombre, el dispositivo que estás usando y elegí el código
+          con el que vas a volver a entrar a tu calendario.
+        </p>
+        <label for="session-name">¿Cómo te llamás?</label>
+        <input
+          type="text"
+          id="session-name"
+          name="name"
+          autocomplete="name"
+          required
+          list="known-users"
+        />
+        <datalist id="known-users"></datalist>
+        <fieldset class="device-options">
+          <legend>¿Desde dónde estás entrando?</legend>
+          <label>
+            <input type="radio" name="device" value="mobile" required />
+            Celular
+          </label>
+          <label>
+            <input type="radio" name="device" value="desktop" />
+            Computadora
+          </label>
+        </fieldset>
+        <label for="session-code" class="sync-label">Elegí tu código personal</label>
+        <input
+          type="text"
+          id="session-code"
+          name="account-code"
+          maxlength="32"
+          pattern="[A-Za-z0-9_-]{4,32}"
+          placeholder="Ej: mi-calendario-2024"
+          autocomplete="off"
+          required
+        />
+        <p class="session-hint">
+          Usá entre 4 y 32 caracteres. Podés combinar letras, números, guiones y
+          guiones bajos.
+        </p>
+        <label for="sync-input" class="sync-label">
+          ¿Tenés un código guardado? Pegalo acá (opcional)
+        </label>
+        <textarea
+          id="sync-input"
+          name="sync"
+          rows="2"
+          placeholder="Ej: mi-calendario-2024::AAECAwQ..."
+        ></textarea>
+        <p id="session-error" class="session-error" role="alert" aria-live="assertive"></p>
+        <button type="submit" class="primary-button">Continuar</button>
+      </form>
+    </section>
+
+    <main class="app hidden" id="app-root">
+      <header class="hero">
+        <h1>Diseña tu calendario soñado</h1>
+        <p>
+          Describe el estilo que imaginás y nuestra IA te sugerirá distintas
+          opciones visuales para tu calendario. ¡Elegí la que más te guste y se
+          generará al instante!
+        </p>
+      </header>
+
+      <section class="session-info hidden" id="session-info" aria-live="polite">
+        <div class="card session-summary">
+          <div class="session-summary-header">
+            <h2 id="session-greeting">¡Hola!</h2>
+            <button type="button" class="link-button" id="switch-user">
+              Cambiar de persona
+            </button>
+          </div>
+          <p id="session-device" class="session-device"></p>
+          <p id="session-theme" class="session-theme"></p>
+          <p id="session-code-display" class="session-code-display"></p>
+          <div class="sync-area">
+            <p class="sync-description">
+              Copiá tu código completo para restaurar el calendario en otro
+              dispositivo. Incluye tu alias y toda la información guardada.
+            </p>
+            <div class="sync-code-box">
+              <code id="sync-code" tabindex="0"></code>
+              <button type="button" class="secondary-button" id="copy-sync-button">
+                Copiar código
+              </button>
+            </div>
+            <p id="sync-feedback" class="sync-feedback" aria-live="polite"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="preferences" aria-labelledby="preferences-title">
+        <div class="card">
+          <h2 id="preferences-title">Contanos tu estilo</h2>
+          <form id="preferences-form">
+            <label for="style-input">
+              ¿Cómo querés que se vea tu calendario? Podés mencionar colores,
+              estados de ánimo o referencias de estilo.
+            </label>
+            <textarea
+              id="style-input"
+              name="style"
+              placeholder="Ej: Quiero algo oscuro, elegante y minimalista"
+              rows="3"
+              required
+            ></textarea>
+            <button type="submit" class="primary-button">
+              Pedir sugerencias inteligentes
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <section class="suggestions" aria-live="polite">
+        <h2>Sugerencias generadas por IA</h2>
+        <p class="empty-state">Ingresá tus preferencias para ver propuestas.</p>
+        <div id="suggestion-list" class="suggestion-list" role="list"></div>
+      </section>
+
+      <section class="calendar-section" aria-live="polite">
+        <h2>Vista previa del calendario</h2>
+        <div id="calendar-container" class="calendar hidden">
+          <div class="calendar-header">
+            <button
+              type="button"
+              class="nav-button"
+              id="prev-month"
+              aria-label="Mes anterior"
+            >
+              ◀
+            </button>
+            <div>
+              <p id="calendar-month" class="calendar-month"></p>
+              <p id="calendar-theme" class="calendar-theme"></p>
+            </div>
+            <button
+              type="button"
+              class="nav-button"
+              id="next-month"
+              aria-label="Mes siguiente"
+            >
+              ▶
+            </button>
+          </div>
+          <div class="calendar-grid" role="grid"></div>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="event-modal"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="event-modal-title"
+    >
+      <div class="modal-content">
+        <button
+          type="button"
+          class="modal-close"
+          id="close-event-modal"
+          aria-label="Cerrar"
+        >
+          ×
+        </button>
+        <h3 id="event-modal-title">Agregar evento</h3>
+        <p id="event-date-label" class="event-date-label"></p>
+        <form id="event-form" class="modal-form">
+          <label for="event-time">Hora</label>
+          <input type="time" id="event-time" name="time" required />
+
+          <label for="event-title">Evento</label>
+          <input
+            type="text"
+            id="event-title"
+            name="title"
+            placeholder="Ej: Reunión con el equipo"
+            maxlength="80"
+            required
+          />
+
+          <button type="submit" class="primary-button">Guardar evento</button>
+        </form>
+      </div>
+    </div>
+
+    <template id="suggestion-card-template">
+      <article class="suggestion-card" role="listitem">
+        <div class="palette" aria-hidden="true"></div>
+        <div class="suggestion-content">
+          <h3 class="suggestion-title"></h3>
+          <p class="suggestion-description"></p>
+          <p class="suggestion-explanation"></p>
+          <button type="button" class="secondary-button">Elegir este estilo</button>
+        </div>
+      </article>
+    </template>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1536 @@
+const styleForm = document.getElementById("preferences-form");
+const styleInput = document.getElementById("style-input");
+const suggestionList = document.getElementById("suggestion-list");
+const emptyState = document.querySelector(".empty-state");
+const suggestionTemplate = document.getElementById("suggestion-card-template");
+const calendarContainer = document.getElementById("calendar-container");
+const calendarGrid = document.querySelector(".calendar-grid");
+const calendarMonthLabel = document.getElementById("calendar-month");
+const calendarThemeLabel = document.getElementById("calendar-theme");
+const prevMonthBtn = document.getElementById("prev-month");
+const nextMonthBtn = document.getElementById("next-month");
+const heroSection = document.querySelector(".hero");
+const preferencesSection = document.querySelector(".preferences");
+const suggestionsSection = document.querySelector(".suggestions");
+
+const sessionScreen = document.getElementById("session-screen");
+const sessionForm = document.getElementById("session-form");
+const sessionNameInput = document.getElementById("session-name");
+const knownUsersList = document.getElementById("known-users");
+const sessionCodeInput = document.getElementById("session-code");
+const syncInput = document.getElementById("sync-input");
+const sessionError = document.getElementById("session-error");
+const sessionInfoSection = document.getElementById("session-info");
+const sessionGreeting = document.getElementById("session-greeting");
+const sessionDeviceLabel = document.getElementById("session-device");
+const sessionThemeLabel = document.getElementById("session-theme");
+const sessionCodeDisplay = document.getElementById("session-code-display");
+const syncCodeElement = document.getElementById("sync-code");
+const copySyncButton = document.getElementById("copy-sync-button");
+const syncFeedback = document.getElementById("sync-feedback");
+const switchUserButton = document.getElementById("switch-user");
+const appRoot = document.getElementById("app-root");
+
+const eventModal = document.getElementById("event-modal");
+const eventForm = document.getElementById("event-form");
+const eventTitleInput = document.getElementById("event-title");
+const eventTimeInput = document.getElementById("event-time");
+const eventDateLabel = document.getElementById("event-date-label");
+const closeEventModalBtn = document.getElementById("close-event-modal");
+
+const monthNames = [
+  "Enero",
+  "Febrero",
+  "Marzo",
+  "Abril",
+  "Mayo",
+  "Junio",
+  "Julio",
+  "Agosto",
+  "Septiembre",
+  "Octubre",
+  "Noviembre",
+  "Diciembre",
+];
+
+const weekDays = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
+
+const DEFAULT_THEME = {
+  name: "Clásico Azul",
+  description: "Un punto de partida equilibrado con azules suaves, detalles modernos y un toque profesional.",
+  explanation:
+    "Tema base para explorar la app mientras la IA genera propuestas personalizadas.",
+  palette: ["#e0f2fe", "#bae6fd", "#3b82f6", "#1e3a8a"],
+  tokens: {
+    background: "linear-gradient(180deg,#e0f2fe,#f8fafc)",
+    card: "rgba(255,255,255,0.92)",
+    accent: "#3b82f6",
+    accentStrong: "#1e3a8a",
+    text: "#0f172a",
+    muted: "#475569",
+    border: "rgba(59,130,246,0.18)",
+    highlight: "rgba(59,130,246,0.2)",
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+};
+
+const MOOD_PRESETS = [
+  {
+    id: "minimal",
+    name: "Minimalismo Nórdico",
+    description: "Líneas limpias, fondos suaves y énfasis en la organización.",
+    keywords: ["minimal", "simple", "limpio", "ordenado", "escandinavo", "blanco", "sutil"],
+    basePalette: ["#f8fafc", "#e2e8f0", "#0f172a", "#38bdf8"],
+    tone: "light",
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+  {
+    id: "tropical",
+    name: "Explosión Tropical",
+    description: "Combinaciones vibrantes inspiradas en playas y atardeceres.",
+    keywords: ["tropical", "verano", "playa", "coral", "vibrante", "divertido", "energico", "energía"],
+    basePalette: ["#fff7ed", "#fde68a", "#f97316", "#10b981"],
+    tone: "light",
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+  {
+    id: "midnight",
+    name: "Nocturno Neón",
+    description: "Contraste de luces brillantes sobre un fondo oscuro futurista.",
+    keywords: ["oscuro", "nocturno", "neon", "neón", "futurista", "cyber", "galaxia", "gamer"],
+    basePalette: ["#020617", "#1e293b", "#38bdf8", "#f472b6"],
+    tone: "dark",
+    font: '"Space Grotesk", "Poppins", sans-serif',
+  },
+  {
+    id: "nature",
+    name: "Raíces Naturales",
+    description: "Verdes orgánicos, texturas orgánicas y sensaciones de calma.",
+    keywords: ["naturaleza", "bosque", "verde", "hojas", "orgánico", "eco", "montaña", "tierra"],
+    basePalette: ["#f1f5f2", "#d1fae5", "#22c55e", "#166534"],
+    tone: "light",
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+  {
+    id: "luxury",
+    name: "Elegancia Dorada",
+    description: "Contraste sofisticado con destellos metálicos y tipografía refinada.",
+    keywords: ["elegante", "lujoso", "glam", "dorado", "oro", "evento", "boda", "premium"],
+    basePalette: ["#0f172a", "#1f2937", "#fbbf24", "#f59e0b"],
+    tone: "dark",
+    font: '"Playfair Display", "Poppins", serif',
+  },
+  {
+    id: "retro",
+    name: "Retro Pastel",
+    description: "Colores suaves y nostalgia moderna inspirada en los 80s y 90s.",
+    keywords: ["retro", "vintage", "nostalgia", "pastel", "suave", "ochentas", "noventas"],
+    basePalette: ["#f5f3ff", "#fde2f3", "#f472b6", "#6366f1"],
+    tone: "light",
+    font: '"Space Grotesk", "Poppins", sans-serif',
+  },
+  {
+    id: "productivity",
+    name: "Productividad Pro",
+    description: "Claridad profesional con jerarquías marcadas y enfoque en la agenda.",
+    keywords: ["profesional", "corporativo", "oficina", "negocios", "productivo", "planificacion", "planificación"],
+    basePalette: ["#f8fafc", "#e0f2fe", "#2563eb", "#1e40af"],
+    tone: "light",
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+];
+
+const COLOR_KEYWORDS = [
+  { labels: ["azul", "azules", "blue", "marino"], hex: "#2563eb" },
+  { labels: ["celeste", "turquesa", "cyan"], hex: "#0ea5e9" },
+  { labels: ["verde", "esmeralda", "menta"], hex: "#22c55e" },
+  { labels: ["rosa", "rosado", "magenta"], hex: "#f472b6" },
+  { labels: ["rojo", "granate", "bordo", "burgundy"], hex: "#ef4444" },
+  { labels: ["naranja", "coral", "mandarina"], hex: "#fb923c" },
+  { labels: ["amarillo", "dorado", "oro"], hex: "#facc15" },
+  { labels: ["violeta", "morado", "lila"], hex: "#8b5cf6" },
+  { labels: ["negro", "grafito", "carbon"], hex: "#111827" },
+  { labels: ["blanco", "marfil", "nieve"], hex: "#f8fafc" },
+];
+
+const ADJECTIVE_KEYWORDS = [
+  { labels: ["minimal", "simple", "limpio", "ordenado"], tag: "minimalista" },
+  { labels: ["elegante", "lujoso", "premium", "sofisticado"], tag: "elegante" },
+  { labels: ["divertido", "vibrante", "energetico", "energico", "colorido"], tag: "vibrante" },
+  { labels: ["calido", "cálido", "acogedor", "hogareno", "hogareño"], tag: "cálido" },
+  { labels: ["fresco", "natural", "relajante", "zen"], tag: "relajante" },
+  { labels: ["retro", "vintage", "nostalgico", "nostálgico"], tag: "retro" },
+  { labels: ["futurista", "cyber", "digital", "tecnologico", "tecnológico"], tag: "futurista" },
+];
+
+const SPECIAL_OCCASIONS = [
+  {
+    labels: ["navidad", "christmas", "festivo"],
+    name: "Magia Navideña",
+    palette: ["#fef3c7", "#fcd34d", "#dc2626", "#166534"],
+    tone: "light",
+    description: "Brillos cálidos, rojos intensos y verdes clásicos para celebraciones de fin de año.",
+  },
+  {
+    labels: ["halloween", "calabaza", "oscuro terror"],
+    name: "Noche de Halloween",
+    palette: ["#1f2937", "#312e81", "#f97316", "#f59e0b"],
+    tone: "dark",
+    description: "Contrastes dramáticos con acentos naranja y violeta que evocan misterio.",
+  },
+  {
+    labels: ["primavera", "flores", "floral"],
+    name: "Flores de Primavera",
+    palette: ["#fdf2f8", "#fce7f3", "#f472b6", "#10b981"],
+    tone: "light",
+    description: "Paleta floral llena de luz y matices suaves inspirados en jardines en flor.",
+  },
+  {
+    labels: ["otoño", "fall", "hojas secas"],
+    name: "Otoño Cálido",
+    palette: ["#fff7ed", "#fed7aa", "#fb923c", "#92400e"],
+    tone: "light",
+    description: "Colores terrosos, cálidos y envolventes para un ambiente acogedor.",
+  },
+];
+
+const FONT_PREFERENCES = [
+  {
+    labels: ["serif", "editorial", "clasico", "classy"],
+    font: '"Playfair Display", "Poppins", serif',
+  },
+  {
+    labels: ["tecnico", "tech", "futurista", "digital"],
+    font: '"Space Grotesk", "Poppins", sans-serif',
+  },
+  {
+    labels: ["mano", "handwriting", "caligrafia", "caligrafia"],
+    font: '"Playfair Display", "Poppins", serif',
+  },
+  {
+    labels: ["redondeado", "amigable", "friendly"],
+    font: '"Poppins", "Segoe UI", sans-serif',
+  },
+];
+
+const STORAGE_KEY = "customCalendar.users";
+const LAST_USER_KEY = "customCalendar.lastUser";
+
+const deviceInputs = sessionForm
+  ? Array.from(sessionForm.querySelectorAll('input[name="device"]'))
+  : [];
+
+let syncFeedbackTimeout = null;
+
+const state = {
+  suggestions: [],
+  currentDate: new Date(),
+  selectedTheme: DEFAULT_THEME,
+  isLoading: false,
+  events: {},
+  themeLocked: false,
+  activeDateKey: null,
+  profile: null,
+};
+
+styleForm.addEventListener("submit", handleFormSubmit);
+prevMonthBtn.addEventListener("click", () => changeMonth(-1));
+nextMonthBtn.addEventListener("click", () => changeMonth(1));
+eventForm.addEventListener("submit", handleEventSubmit);
+closeEventModalBtn.addEventListener("click", closeEventModal);
+eventModal.addEventListener("click", (event) => {
+  if (event.target === eventModal) {
+    closeEventModal();
+  }
+});
+document.addEventListener("keydown", handleGlobalKeydown);
+
+sessionForm?.addEventListener("submit", handleSessionSubmit);
+sessionNameInput?.addEventListener("input", handleNameInputChange);
+copySyncButton?.addEventListener("click", handleCopySyncCode);
+switchUserButton?.addEventListener("click", () => {
+  if (syncInput) {
+    syncInput.value = "";
+  }
+  showSessionScreen(true);
+});
+
+applyTheme(DEFAULT_THEME);
+renderCalendar();
+calendarThemeLabel.textContent = `${DEFAULT_THEME.name} (base)`;
+calendarContainer.classList.remove("hidden");
+
+initializeSession();
+
+async function handleFormSubmit(event) {
+  event.preventDefault();
+  if (state.themeLocked) {
+    return;
+  }
+  const preferences = styleInput.value.trim();
+  if (!preferences) return;
+
+  updateStatus("Buscando estilos con ayuda de la IA…", "loading");
+  setLoading(true);
+
+  try {
+    const suggestions = await generateThemesWithAI(preferences);
+    state.suggestions = suggestions;
+    renderSuggestions();
+    if (suggestions.length) {
+      updateStatus("Elegí uno de los estilos sugeridos para aplicarlo al calendario.");
+    } else {
+      updateStatus(
+        "La IA no pudo generar ideas con esa descripción. Probá con más detalles o referencias.",
+        "error"
+      );
+    }
+  } catch (error) {
+    console.error(error);
+    updateStatus(error.message || "Ocurrió un error al generar sugerencias.", "error");
+    suggestionList.innerHTML = "";
+  } finally {
+    setLoading(false);
+  }
+}
+
+function setLoading(isLoading) {
+  state.isLoading = isLoading;
+  styleForm.querySelector("button[type='submit']").disabled = isLoading;
+}
+
+function updateStatus(message, variant = "info") {
+  if (!emptyState) return;
+  emptyState.textContent = message;
+  emptyState.classList.remove("error", "loading");
+  if (variant !== "info") emptyState.classList.add(variant);
+}
+
+function renderSuggestions() {
+  suggestionList.innerHTML = "";
+  state.suggestions.forEach((suggestion, index) => {
+    const card = createSuggestionCard(suggestion, index);
+    suggestionList.appendChild(card);
+  });
+}
+
+function createSuggestionCard(suggestion, index) {
+  const node = suggestionTemplate.content.firstElementChild.cloneNode(true);
+  const palette = node.querySelector(".palette");
+  const title = node.querySelector(".suggestion-title");
+  const description = node.querySelector(".suggestion-description");
+  const explanation = node.querySelector(".suggestion-explanation");
+  const button = node.querySelector(".secondary-button");
+
+  title.textContent = suggestion.name || `Estilo ${index + 1}`;
+  description.textContent = suggestion.description?.trim() || "Estilo sugerido por la IA.";
+  explanation.textContent = suggestion.explanation?.trim() ||
+    suggestion.reason?.trim() ||
+    "Generado automáticamente a partir de tus preferencias.";
+
+  palette.innerHTML = "";
+  (suggestion.palette || []).forEach((color) => {
+    const swatch = document.createElement("span");
+    swatch.style.background = color;
+    swatch.title = color;
+    palette.appendChild(swatch);
+  });
+
+  button.addEventListener("click", () => {
+    state.selectedTheme = suggestion;
+    applyTheme(suggestion);
+    highlightSelectedCard(node);
+    finalizeThemeSelection();
+  });
+
+  if (state.selectedTheme && state.selectedTheme === suggestion) {
+    node.classList.add("selected");
+  }
+
+  return node;
+}
+
+function highlightSelectedCard(selectedNode) {
+  suggestionList.querySelectorAll(".suggestion-card").forEach((card) => {
+    card.classList.toggle("selected", card === selectedNode);
+  });
+}
+
+function finalizeThemeSelection() {
+  if (state.themeLocked) return;
+  state.themeLocked = true;
+  updateThemeLockUI();
+  styleForm.reset();
+  persistUserState();
+}
+
+function applyTheme(theme) {
+  if (!theme) return;
+
+  const tokens = withFallbackTokens(theme.tokens || {});
+  const root = document.documentElement.style;
+  root.setProperty("--background-color", tokens.background);
+  root.setProperty("--card-background", tokens.card);
+  root.setProperty("--accent-color", tokens.accent);
+  root.setProperty("--accent-color-strong", tokens.accentStrong);
+  root.setProperty("--text-color", tokens.text);
+  root.setProperty("--muted-text", tokens.muted);
+  root.setProperty("--calendar-border", tokens.border);
+  root.setProperty("--highlight-color", tokens.highlight);
+  if (tokens.font) {
+    root.setProperty("--font-family", tokens.font);
+  }
+
+  const themeName = theme.name || "Tema personalizado";
+  const shouldShowBase = themeName === DEFAULT_THEME.name && !state.themeLocked;
+  calendarThemeLabel.textContent = shouldShowBase
+    ? `${themeName} (base)`
+    : themeName;
+  calendarContainer.classList.remove("hidden");
+  document.body.classList.toggle("auto-dark", prefersDarkPalette(tokens));
+  renderCalendar();
+  if (state.profile) {
+    persistUserState();
+  }
+}
+
+function withFallbackTokens(tokens) {
+  return {
+    background: tokens.background || DEFAULT_THEME.tokens.background,
+    card: tokens.card || DEFAULT_THEME.tokens.card,
+    accent: tokens.accent || DEFAULT_THEME.tokens.accent,
+    accentStrong: tokens.accentStrong || tokens.accent || DEFAULT_THEME.tokens.accentStrong,
+    text: tokens.text || "#111827",
+    muted: tokens.muted || "#4b5563",
+    border: tokens.border || "rgba(148, 163, 184, 0.25)",
+    highlight: tokens.highlight || "rgba(148, 163, 184, 0.2)",
+    font: tokens.font || DEFAULT_THEME.tokens.font,
+  };
+}
+
+function prefersDarkPalette(tokens) {
+  const textColor = tokens.text?.replace("#", "");
+  if (!textColor) return false;
+  const r = parseInt(textColor.substring(0, 2), 16);
+  const g = parseInt(textColor.substring(2, 4), 16);
+  const b = parseInt(textColor.substring(4, 6), 16);
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luminance > 0.75; // texto muy claro implica fondo oscuro
+}
+
+async function generateThemesWithAI(preferences) {
+  const analysis = analyzePreferences(preferences);
+  await simulateThinkingDelay(analysis);
+
+  const suggestions = buildSuggestionsFromAnalysis(analysis);
+  if (!suggestions.length) {
+    throw new Error("No se pudieron componer estilos con esa descripción. Probá con más detalles o referencias.");
+  }
+
+  return suggestions;
+}
+
+function changeMonth(offset) {
+  const current = state.currentDate;
+  const newDate = new Date(current.getFullYear(), current.getMonth() + offset, 1);
+  state.currentDate = newDate;
+  renderCalendar();
+}
+
+function renderCalendar() {
+  const date = state.currentDate;
+  const year = date.getFullYear();
+  const month = date.getMonth();
+
+  calendarGrid.innerHTML = "";
+  calendarMonthLabel.textContent = `${monthNames[month]} ${year}`;
+
+  weekDays.forEach((day) => {
+    const cell = document.createElement("div");
+    cell.className = "calendar-cell header";
+    cell.textContent = day;
+    calendarGrid.appendChild(cell);
+  });
+
+  const firstDay = new Date(year, month, 1);
+  const offset = (firstDay.getDay() + 6) % 7; // Lunes como primer día
+  for (let i = 0; i < offset; i += 1) {
+    const emptyCell = document.createElement("div");
+    emptyCell.className = "calendar-cell empty";
+    calendarGrid.appendChild(emptyCell);
+  }
+
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const today = new Date();
+  const todayReference = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate()
+  );
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const dateKey = buildDateKey(year, month, day);
+    const cell = document.createElement("div");
+    cell.className = "calendar-cell day-cell";
+    cell.dataset.dateKey = dateKey;
+    cell.setAttribute("role", "button");
+    cell.setAttribute("aria-label", buildCellAriaLabel(year, month, day));
+    cell.tabIndex = 0;
+
+    const cellDate = new Date(year, month, day);
+    if (cellDate < todayReference) {
+      cell.classList.add("past-day");
+    }
+
+    if (
+      day === today.getDate() &&
+      month === today.getMonth() &&
+      year === today.getFullYear()
+    ) {
+      cell.classList.add("today");
+    }
+
+    const eventsContainer = document.createElement("div");
+    eventsContainer.className = "events-container";
+
+    const eventsForDay = getEventsForDate(dateKey);
+    if (eventsForDay.length) {
+      cell.classList.add("has-events");
+      eventsForDay.forEach((event) => {
+        const eventChip = document.createElement("div");
+        eventChip.className = "event-chip";
+
+        const timeElement = document.createElement("strong");
+        timeElement.textContent = event.time;
+
+        const titleElement = document.createElement("span");
+        titleElement.textContent = event.title;
+
+        eventChip.appendChild(timeElement);
+        eventChip.appendChild(titleElement);
+        eventsContainer.appendChild(eventChip);
+      });
+    }
+
+    const resetButton = buildDayResetButton(dateKey);
+    const dayNumber = document.createElement("span");
+    dayNumber.className = "day-number";
+    dayNumber.textContent = day;
+
+    cell.appendChild(resetButton);
+    cell.appendChild(eventsContainer);
+    cell.appendChild(dayNumber);
+
+    cell.addEventListener("click", () => openEventModal(dateKey));
+    cell.addEventListener("keydown", (event) => handleDayKeydown(event, dateKey));
+
+    calendarGrid.appendChild(cell);
+  }
+}
+
+function buildDateKey(year, monthIndex, day) {
+  return `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function buildDayResetButton(dateKey) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "day-reset-button";
+  button.setAttribute("aria-label", `Limpiar eventos del ${formatDateLabel(dateKey)}`);
+
+  const icon = document.createElement("span");
+  icon.className = "reset-icon";
+  icon.setAttribute("aria-hidden", "true");
+  icon.textContent = "⟳";
+
+  const srLabel = document.createElement("span");
+  srLabel.className = "sr-only";
+  srLabel.textContent = "Reiniciar día";
+
+  button.appendChild(icon);
+  button.appendChild(srLabel);
+
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    clearEventsForDate(dateKey);
+  });
+
+  return button;
+}
+
+function buildCellAriaLabel(year, monthIndex, day) {
+  const key = buildDateKey(year, monthIndex, day);
+  const base = `${day} de ${monthNames[monthIndex]} de ${year}`;
+  const events = getEventsForDate(key);
+  if (!events.length) return base;
+  const suffix = events.length === 1 ? "1 evento" : `${events.length} eventos`;
+  return `${base}, ${suffix}`;
+}
+
+function getEventsForDate(dateKey) {
+  const events = state.events[dateKey] || [];
+  return [...events].sort((a, b) => a.time.localeCompare(b.time));
+}
+
+function openEventModal(dateKey) {
+  if (!state.profile) {
+    return;
+  }
+  state.activeDateKey = dateKey;
+  eventForm.reset();
+  eventModal.classList.remove("hidden");
+  document.body.classList.add("modal-open");
+  eventDateLabel.textContent = formatDateLabel(dateKey);
+  window.setTimeout(() => eventTimeInput.focus(), 50);
+}
+
+function closeEventModal() {
+  eventModal.classList.add("hidden");
+  document.body.classList.remove("modal-open");
+  state.activeDateKey = null;
+}
+
+function handleEventSubmit(event) {
+  event.preventDefault();
+  const title = eventTitleInput.value.trim();
+  const time = eventTimeInput.value;
+
+  if (!title || !time || !state.activeDateKey) {
+    return;
+  }
+
+  if (!state.events[state.activeDateKey]) {
+    state.events[state.activeDateKey] = [];
+  }
+
+  state.events[state.activeDateKey].push({
+    title,
+    time,
+  });
+
+  state.events[state.activeDateKey].sort((a, b) => a.time.localeCompare(b.time));
+
+  renderCalendar();
+  persistUserState();
+  closeEventModal();
+}
+
+function handleDayKeydown(event, dateKey) {
+  if (event.target !== event.currentTarget) {
+    return;
+  }
+
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    openEventModal(dateKey);
+  }
+}
+
+function handleGlobalKeydown(event) {
+  if (event.key === "Escape" && !eventModal.classList.contains("hidden")) {
+    closeEventModal();
+  }
+}
+
+function formatDateLabel(dateKey) {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const readableMonth = monthNames[month - 1] || "";
+  return `${day} de ${readableMonth} de ${year}`;
+}
+
+function clearEventsForDate(dateKey) {
+  if (!state.events[dateKey] || state.events[dateKey].length === 0) {
+    return;
+  }
+
+  delete state.events[dateKey];
+  renderCalendar();
+  persistUserState();
+}
+
+function analyzePreferences(preferences) {
+  const raw = preferences.trim();
+  const normalized = normalizeText(raw);
+
+  const colors = detectPreferredColors(normalized);
+  const adjectives = detectAdjectives(normalized);
+  const special = detectSpecialOccasion(normalized);
+  const moodScores = scoreMoods(normalized);
+  const preferredFont = detectFontPreference(normalized);
+
+  const wantsDark = /(oscuro|dark|nocturn|galaxia|noche)/.test(normalized);
+  const wantsLight = /(claro|luminoso|brillante|radiante)/.test(normalized);
+  const wantsPastel = /(pastel|suave|apagad)/.test(normalized);
+  const wantsGradient = /(degrad|gradient|gradiente)/.test(normalized);
+  const wantsGlass = /(vidrio|cristal|glass|translucid|translucido)/.test(normalized);
+  const wantsTexture = /(textura|acuarela|papel|granulado|grain)/.test(normalized);
+  const wantsWarm = /(calid|sunset|atardecer|otono|oto\b)/.test(normalized);
+  const wantsNature = /(naturaleza|bosque|hoja|eco|botanic)/.test(normalized);
+  const wantsModern = /(moderno|tech|digital|futurista|minimal)/.test(normalized);
+
+  return {
+    raw,
+    normalized,
+    colors,
+    adjectives,
+    special,
+    moodScores,
+    font: preferredFont,
+    wantsDark,
+    wantsLight,
+    wantsPastel,
+    wantsGradient,
+    wantsGlass,
+    wantsTexture,
+    wantsWarm,
+    wantsNature,
+    wantsModern,
+  };
+}
+
+function buildSuggestionsFromAnalysis(analysis) {
+  const candidates = selectMoodCandidates(analysis);
+  return candidates.map((preset, index) => createSuggestionFromPreset(preset, analysis, index));
+}
+
+function selectMoodCandidates(analysis) {
+  const ranked = [...analysis.moodScores].sort((a, b) => b.score - a.score);
+  const selected = [];
+
+  if (analysis.special) {
+    selected.push({
+      ...analysis.special,
+      id: `special-${analysis.special.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+      basePalette: analysis.special.palette,
+      tone: analysis.special.tone,
+      font: analysis.special.font || '"Poppins", "Segoe UI", sans-serif',
+    });
+  }
+
+  ranked.forEach(({ preset, score }) => {
+    if (selected.length >= 4) return;
+    if (score <= 0 && selected.length >= 3) return;
+    if (!selected.some((item) => item.id === preset.id)) {
+      selected.push(preset);
+    }
+  });
+
+  if (selected.length < 3) {
+    MOOD_PRESETS.forEach((preset) => {
+      if (selected.length >= 3) return;
+      if (!selected.some((item) => item.id === preset.id)) {
+        selected.push(preset);
+      }
+    });
+  }
+
+  return selected.slice(0, 4);
+}
+
+function createSuggestionFromPreset(preset, analysis, index) {
+  const tone = resolveTone(preset, analysis);
+  const palette = createPaletteFromPreferences(preset, analysis, index, tone);
+  const tokens = composeTokens(preset, analysis, palette, tone, index);
+
+  return {
+    name: composeName(preset, analysis, index),
+    description: composeDescription(preset, analysis, tone, palette),
+    explanation: composeExplanation(preset, analysis, tone),
+    palette,
+    tokens,
+  };
+}
+
+function resolveTone(preset, analysis) {
+  if (analysis.wantsDark && !analysis.wantsLight) return "dark";
+  if (analysis.wantsLight && !analysis.wantsDark) return "light";
+  if (analysis.special?.tone) return analysis.special.tone;
+  return preset.tone || "light";
+}
+
+function createPaletteFromPreferences(preset, analysis, index, tone) {
+  let palette = [...(analysis.special?.palette || preset.basePalette || DEFAULT_THEME.palette)];
+  const userColors = analysis.colors;
+
+  if (userColors.length) {
+    const primary = userColors[0].hex;
+    const secondary = userColors[1]?.hex || adjustColor(primary, index % 2 === 0 ? -25 : 20);
+    const baseSoft = lightenColor(primary, analysis.wantsPastel ? 55 : 35);
+    const baseMid = lightenColor(primary, analysis.wantsPastel ? 40 : 18);
+    palette = [baseSoft, baseMid, primary, secondary];
+  }
+
+  if (analysis.wantsPastel) {
+    palette = palette.map((hex, idx) => lightenColor(hex, idx < 2 ? 20 : 8));
+  }
+
+  if (analysis.wantsWarm && !analysis.colors.length) {
+    palette = palette.map((hex, idx) => (idx < 2 ? warmColor(hex, 12) : warmColor(hex, 6)));
+  }
+
+  if (analysis.wantsNature && !analysis.colors.length && preset.id !== "nature") {
+    palette = palette.map((hex, idx) => (idx > 1 ? mixColor(hex, "#166534", 0.35) : mixColor(hex, "#bbf7d0", 0.25)));
+  }
+
+  if (tone === "dark" && !analysis.wantsPastel) {
+    palette = palette.map((hex, idx) => (idx < 2 ? darkenColor(hex, 25) : hex));
+  }
+
+  return palette.map(normalizeHex);
+}
+
+function composeTokens(preset, analysis, palette, tone, index) {
+  const accent = palette[2] || preset.basePalette?.[2] || DEFAULT_THEME.palette[2];
+  const accentStrong = palette[3] || adjustColor(accent, tone === "dark" ? -30 : -18);
+  let background;
+
+  if (analysis.wantsGradient || analysis.wantsPastel) {
+    background = `linear-gradient(180deg, ${palette[0]}, ${palette[1]})`;
+  } else if (tone === "dark") {
+    const glowColor = hexToRgba(accent, 0.35);
+    background = `radial-gradient(circle at ${index % 2 === 0 ? "20%" : "80%"} 0%, ${glowColor}, #020617 70%)`;
+  } else {
+    background = `linear-gradient(180deg, ${palette[0]}, ${lightenColor(palette[1], 12)})`;
+  }
+
+  if (analysis.special && index === 0) {
+    background = `linear-gradient(160deg, ${palette[0]}, ${palette[2]})`;
+  }
+
+  const textColor = tone === "dark" ? "#e2e8f0" : "#0f172a";
+  const muted = tone === "dark" ? "#94a3b8" : "#475569";
+
+  const font = analysis.font || preset.font || DEFAULT_THEME.tokens.font;
+  const card = tone === "dark" ? "rgba(15,23,42,0.85)" : "rgba(255,255,255,0.92)";
+
+  return {
+    background,
+    card,
+    accent,
+    accentStrong,
+    text: textColor,
+    muted,
+    border: hexToRgba(accentStrong, tone === "dark" ? 0.38 : 0.22),
+    highlight: hexToRgba(accent, tone === "dark" ? 0.24 : 0.18),
+    font,
+  };
+}
+
+function composeName(preset, analysis, index) {
+  if (analysis.special && index === 0) {
+    return decorateName(analysis.special.name, analysis.colors, analysis.adjectives);
+  }
+
+  const colorTag = analysis.colors[0]?.label;
+  const adjective = analysis.adjectives[0];
+  let baseName = preset.name;
+
+  if (colorTag && !baseName.toLowerCase().includes(colorTag)) {
+    baseName = `${baseName} ${capitalize(colorTag)}`;
+  }
+
+  if (adjective && !baseName.toLowerCase().includes(adjective)) {
+    baseName = `${baseName} ${capitalize(adjective)}`;
+  }
+
+  if (index === 1) {
+    baseName = `${baseName} Alterno`;
+  } else if (index === 2) {
+    baseName = `${baseName} Concepto`;
+  }
+
+  return baseName.trim();
+}
+
+function composeDescription(preset, analysis, tone, palette) {
+  const fragments = [];
+
+  if (analysis.colors.length) {
+    const colorLabels = analysis.colors.map((c) => c.label).join(" y ");
+    fragments.push(`paleta protagonista en ${colorLabels}`);
+  }
+
+  if (analysis.adjectives.length) {
+    fragments.push(`sensación ${analysis.adjectives.join(" y ")}`);
+  }
+
+  if (analysis.wantsGradient) {
+    fragments.push("degradados suaves para dar profundidad");
+  }
+
+  if (analysis.wantsGlass) {
+    fragments.push("detalles translúcidos estilo glassmorphism");
+  }
+
+  if (analysis.wantsTexture) {
+    fragments.push("texturas ligeras que aportan carácter");
+  }
+
+  if (tone === "dark") {
+    fragments.push("contraste alto sobre fondo profundo");
+  }
+
+  if (analysis.wantsModern) {
+    fragments.push("geometría moderna para mantener la interfaz limpia");
+  }
+
+  if (analysis.wantsNature) {
+    fragments.push("inspiración orgánica en cada bloque del calendario");
+  }
+
+  if (analysis.wantsWarm) {
+    fragments.push("matices cálidos que evocan atardeceres");
+  }
+
+  const details = fragments.length ? `${capitalizeFirst(fragments[0])}${fragments.slice(1).map((item) => `, ${item}`).join("")}.` : "";
+
+  const baseDescription = analysis.special?.description || preset.description || DEFAULT_THEME.description;
+  const closing = palette && palette.length ? ` Paleta sugerida: ${palette.map((color) => color.toUpperCase()).join(", ")}.` : "";
+
+  return `${baseDescription}${details ? ` ${details}` : ""}${closing}`.trim();
+}
+
+function composeExplanation(preset, analysis, tone) {
+  const reasons = [];
+
+  if (analysis.special) {
+    reasons.push(`la temática ${analysis.special.name.toLowerCase()}`);
+  }
+
+  if (analysis.adjectives.length) {
+    reasons.push(`tu pedido ${analysis.adjectives.join(" y ")}`);
+  }
+
+  if (analysis.colors.length) {
+    reasons.push(`los colores ${analysis.colors.map((c) => c.label).join(" y ")}`);
+  }
+
+  if (analysis.wantsGradient) {
+    reasons.push("el interés por usar degradados");
+  }
+
+  if (analysis.wantsGlass) {
+    reasons.push("la referencia a cristales y transparencias");
+  }
+
+  if (analysis.wantsTexture) {
+    reasons.push("las texturas mencionadas");
+  }
+
+  if (analysis.wantsNature) {
+    reasons.push("el enfoque natural que mencionaste");
+  }
+
+  if (analysis.wantsModern) {
+    reasons.push("tu pedido de un estilo moderno");
+  }
+
+  if (!reasons.length) {
+    reasons.push("las palabras clave que compartiste");
+  }
+
+  const toneNote = tone === "dark" ? "Se ajustó el contraste para que los eventos destaquen sin perder legibilidad." : "Los contrastes se equilibraron para mantener una lectura cómoda.";
+
+  return `Pensado a partir de ${enumerateList(reasons)}. ${toneNote}`;
+}
+
+function simulateThinkingDelay(analysis) {
+  const base = analysis.raw.length > 160 ? 500 : 320;
+  const variance = analysis.moodScores.some((item) => item.score > 1) ? 180 : 80;
+  return new Promise((resolve) => {
+    setTimeout(resolve, base + variance);
+  });
+}
+
+function scoreMoods(normalized) {
+  return MOOD_PRESETS.map((preset) => ({
+    preset,
+    score: preset.keywords.reduce((total, keyword) => {
+      const normalizedKeyword = normalizeText(keyword);
+      return normalized.includes(normalizedKeyword) ? total + 1 : total;
+    }, 0),
+  }));
+}
+
+function detectPreferredColors(normalized) {
+  const colors = [];
+  COLOR_KEYWORDS.forEach((entry) => {
+    if (entry.labels.some((label) => normalized.includes(normalizeText(label)))) {
+      colors.push({ label: entry.labels[0], hex: entry.hex });
+    }
+  });
+  return colors.slice(0, 3);
+}
+
+function detectAdjectives(normalized) {
+  const tags = [];
+  ADJECTIVE_KEYWORDS.forEach((entry) => {
+    if (entry.labels.some((label) => normalized.includes(normalizeText(label)))) {
+      tags.push(entry.tag);
+    }
+  });
+  return [...new Set(tags)].slice(0, 3);
+}
+
+function detectSpecialOccasion(normalized) {
+  for (const occasion of SPECIAL_OCCASIONS) {
+    if (occasion.labels.some((label) => normalized.includes(normalizeText(label)))) {
+      return occasion;
+    }
+  }
+  return null;
+}
+
+function detectFontPreference(normalized) {
+  const match = FONT_PREFERENCES.find((entry) =>
+    entry.labels.some((label) => normalized.includes(normalizeText(label)))
+  );
+  return match ? match.font : null;
+}
+
+function normalizeText(text) {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+function capitalize(text) {
+  if (!text) return "";
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function capitalizeFirst(text) {
+  if (!text) return "";
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+}
+
+function decorateName(base, colors, adjectives) {
+  let name = base;
+  if (colors.length) {
+    name += ` ${capitalize(colors[0].label)}`;
+  }
+  if (adjectives.length) {
+    name += ` ${capitalize(adjectives[0])}`;
+  }
+  return name.trim();
+}
+
+function enumerateList(items) {
+  if (items.length === 1) return items[0];
+  const last = items[items.length - 1];
+  return `${items.slice(0, -1).join(", ")} y ${last}`;
+}
+
+function adjustColor(hex, amount) {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex({
+    r: clampColor(r + amount),
+    g: clampColor(g + amount),
+    b: clampColor(b + amount),
+  });
+}
+
+function lightenColor(hex, amount) {
+  return adjustColor(hex, Math.abs(amount));
+}
+
+function darkenColor(hex, amount) {
+  return adjustColor(hex, -Math.abs(amount));
+}
+
+function warmColor(hex, amount) {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex({
+    r: clampColor(r + amount),
+    g: clampColor(g + Math.round(amount / 4)),
+    b: clampColor(b - Math.round(amount / 3)),
+  });
+}
+
+function mixColor(hexA, hexB, ratio) {
+  const a = hexToRgb(hexA);
+  const b = hexToRgb(hexB);
+  return rgbToHex({
+    r: clampColor(a.r * (1 - ratio) + b.r * ratio),
+    g: clampColor(a.g * (1 - ratio) + b.g * ratio),
+    b: clampColor(a.b * (1 - ratio) + b.b * ratio),
+  });
+}
+
+function normalizeHex(hex) {
+  if (!hex) return "#ffffff";
+  const stripped = hex.replace("#", "");
+  if (stripped.length === 3) {
+    return `#${stripped
+      .split("")
+      .map((char) => char + char)
+      .join("")}`.toLowerCase();
+  }
+  return `#${stripped.substring(0, 6).toLowerCase()}`;
+}
+
+function hexToRgb(hex) {
+  const normalized = normalizeHex(hex).replace("#", "");
+  const r = parseInt(normalized.substring(0, 2), 16) || 0;
+  const g = parseInt(normalized.substring(2, 4), 16) || 0;
+  const b = parseInt(normalized.substring(4, 6), 16) || 0;
+  return { r, g, b };
+}
+
+function rgbToHex({ r, g, b }) {
+  const toHex = (value) => clampColor(Math.round(value)).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexToRgba(hex, alpha) {
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function clampColor(value) {
+  return Math.min(255, Math.max(0, value));
+}
+
+function initializeSession() {
+  updateThemeLockUI();
+  const users = getStoredUsers();
+  populateNameSuggestions(users);
+
+  const lastUser = localStorage.getItem(LAST_USER_KEY);
+  const defaultDevice = detectDefaultDevice();
+  const stored = lastUser ? users[normalizeName(lastUser)] : null;
+
+  if (sessionNameInput) {
+    if (stored?.name) {
+      sessionNameInput.value = stored.name;
+    } else if (lastUser) {
+      sessionNameInput.value = lastUser;
+    } else {
+      sessionNameInput.value = "";
+    }
+  }
+
+  if (sessionCodeInput) {
+    sessionCodeInput.value = stored?.profile?.code || "";
+  }
+
+  selectDeviceRadio(stored?.profile?.device || defaultDevice);
+  applyDeviceClass(stored?.profile?.device || defaultDevice);
+  showSessionScreen(Boolean(lastUser));
+}
+
+function handleSessionSubmit(event) {
+  event.preventDefault();
+  clearSessionError();
+
+  if (!sessionForm) return;
+
+  const name = sessionNameInput?.value.trim();
+  if (!name) {
+    showSessionError("Necesitamos tu nombre para guardar tu calendario.");
+    sessionNameInput?.focus();
+    return;
+  }
+
+  const device = getSelectedDevice();
+  if (!device) {
+    showSessionError("Elegí si estás desde un celular o una computadora.");
+    return;
+  }
+
+  const codePattern = /^[A-Za-z0-9_-]{4,32}$/;
+  let accountCode = sessionCodeInput?.value.trim() || "";
+  const syncCode = syncInput?.value.trim();
+  const users = getStoredUsers();
+  const stored = users[normalizeName(name)];
+  let snapshot = stored || {};
+
+  if (syncCode) {
+    const decoded = decodeSyncSnapshot(syncCode);
+    if (!decoded?.snapshot) {
+      showSessionError("El código de sincronización no es válido.");
+      return;
+    }
+    snapshot = decoded.snapshot;
+    if (!accountCode) {
+      accountCode = decoded.code || snapshot?.profile?.code || "";
+      if (sessionCodeInput) {
+        sessionCodeInput.value = accountCode;
+      }
+    }
+  }
+
+  if (!accountCode) {
+    showSessionError("Elegí un código personal de 4 a 32 caracteres.");
+    sessionCodeInput?.focus();
+    return;
+  }
+
+  if (!codePattern.test(accountCode)) {
+    showSessionError(
+      "El código solo puede tener letras, números, guiones y guiones bajos (4 a 32 caracteres)."
+    );
+    sessionCodeInput?.focus();
+    return;
+  }
+
+  state.profile = {
+    name,
+    device,
+    code: accountCode,
+  };
+
+  applyDeviceClass(device);
+  hydrateStateFromSnapshot(snapshot);
+  if (state.profile && !state.profile.code) {
+    state.profile.code = accountCode;
+  }
+  applyTheme(state.selectedTheme || DEFAULT_THEME);
+  updateThemeLockUI();
+  hideSessionScreen();
+  updateSessionInfo();
+}
+
+function handleNameInputChange() {
+  if (!sessionNameInput) return;
+  const value = sessionNameInput.value.trim();
+  if (!value) return;
+  const users = getStoredUsers();
+  const record = users[normalizeName(value)];
+  if (record?.profile?.device) {
+    selectDeviceRadio(record.profile.device);
+  }
+}
+
+function hydrateStateFromSnapshot(snapshot) {
+  const safeEvents = deepCloneEvents(snapshot?.events || {});
+  const theme = cloneTheme(snapshot?.selectedTheme) || DEFAULT_THEME;
+  state.events = safeEvents;
+  state.selectedTheme = theme;
+  state.themeLocked = Boolean(snapshot?.themeLocked);
+  if (snapshot?.profile?.code && state.profile) {
+    state.profile.code = snapshot.profile.code;
+  }
+}
+
+function showSessionScreen(prefillCurrent = false) {
+  if (!sessionScreen) return;
+  sessionScreen.classList.remove("hidden");
+  sessionScreen.setAttribute("aria-hidden", "false");
+  appRoot?.classList.add("hidden");
+  clearSessionError();
+  if (syncInput) {
+    syncInput.value = "";
+  }
+
+  if (prefillCurrent && state.profile?.name && sessionNameInput) {
+    sessionNameInput.value = state.profile.name;
+    selectDeviceRadio(state.profile.device || detectDefaultDevice());
+    if (sessionCodeInput) {
+      sessionCodeInput.value = state.profile.code || "";
+    }
+  } else if (sessionNameInput && !sessionNameInput.value) {
+    selectDeviceRadio(detectDefaultDevice());
+  }
+
+  window.setTimeout(() => sessionNameInput?.focus(), 80);
+}
+
+function hideSessionScreen() {
+  if (!sessionScreen) return;
+  sessionScreen.classList.add("hidden");
+  sessionScreen.setAttribute("aria-hidden", "true");
+  appRoot?.classList.remove("hidden");
+  clearSessionError();
+  if (syncInput) {
+    syncInput.value = "";
+  }
+}
+
+function showSessionError(message) {
+  if (!sessionError) return;
+  sessionError.textContent = message;
+}
+
+function clearSessionError() {
+  if (!sessionError) return;
+  sessionError.textContent = "";
+}
+
+function selectDeviceRadio(device) {
+  if (!deviceInputs.length) return;
+  deviceInputs.forEach((input) => {
+    input.checked = input.value === device;
+  });
+}
+
+function getSelectedDevice() {
+  const selected = deviceInputs.find((input) => input.checked);
+  return selected ? selected.value : null;
+}
+
+function detectDefaultDevice() {
+  if (typeof window.matchMedia !== "function") {
+    return "desktop";
+  }
+  return window.matchMedia("(max-width: 768px)").matches ? "mobile" : "desktop";
+}
+
+function applyDeviceClass(device) {
+  const className = device === "mobile" ? "device-mobile" : "device-desktop";
+  document.body.classList.remove("device-mobile", "device-desktop");
+  document.body.classList.add(className);
+  if (state.profile) {
+    state.profile.device = device;
+  }
+}
+
+function normalizeName(name) {
+  return name.trim().toLowerCase();
+}
+
+function getStoredUsers() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.error("No se pudieron leer los perfiles guardados", error);
+  }
+  return {};
+}
+
+function saveUsers(users) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
+  } catch (error) {
+    console.error("No se pudo guardar el perfil", error);
+  }
+}
+
+function persistUserState() {
+  if (!state.profile?.name) {
+    return;
+  }
+
+  const key = normalizeName(state.profile.name);
+  const users = getStoredUsers();
+  users[key] = {
+    name: state.profile.name,
+    profile: {
+      name: state.profile.name,
+      device: state.profile.device,
+      code: state.profile.code,
+    },
+    events: deepCloneEvents(state.events),
+    selectedTheme: cloneTheme(state.selectedTheme),
+    themeLocked: state.themeLocked,
+  };
+
+  saveUsers(users);
+  localStorage.setItem(LAST_USER_KEY, state.profile.name);
+  populateNameSuggestions(users);
+  updateSessionInfo();
+}
+
+function populateNameSuggestions(users = getStoredUsers()) {
+  if (!knownUsersList) return;
+  knownUsersList.innerHTML = "";
+  const names = Object.values(users)
+    .map((entry) => entry?.name || entry?.profile?.name)
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+
+  const unique = [...new Set(names)];
+  unique.forEach((name) => {
+    const option = document.createElement("option");
+    option.value = name;
+    knownUsersList.appendChild(option);
+  });
+}
+
+function deepCloneEvents(events) {
+  return JSON.parse(JSON.stringify(events || {}));
+}
+
+function cloneTheme(theme) {
+  if (!theme) return null;
+  return JSON.parse(JSON.stringify(theme));
+}
+
+function generateSyncCode() {
+  if (!state.profile?.name || !state.profile?.code) {
+    return "";
+  }
+
+  const snapshot = {
+    v: 1,
+    profile: {
+      name: state.profile.name,
+      device: state.profile.device,
+      code: state.profile.code,
+    },
+    name: state.profile.name,
+    device: state.profile.device,
+    events: deepCloneEvents(state.events),
+    selectedTheme: cloneTheme(state.selectedTheme),
+    themeLocked: state.themeLocked,
+  };
+
+  const encoded = encodeSnapshot(snapshot);
+  if (!encoded) {
+    return "";
+  }
+
+  return `${state.profile.code}::${encoded}`;
+}
+
+function encodeSnapshot(payload) {
+  try {
+    const json = JSON.stringify(payload);
+    const bytes = new TextEncoder().encode(json);
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  } catch (error) {
+    console.error("No se pudo generar el código de sincronización", error);
+    return "";
+  }
+}
+
+function decodeSyncSnapshot(code) {
+  if (!code) return null;
+  try {
+    const trimmed = code.trim();
+    const separatorIndex = trimmed.indexOf("::");
+    let alias = "";
+    let encoded = trimmed;
+
+    if (separatorIndex !== -1) {
+      alias = trimmed.slice(0, separatorIndex).trim();
+      encoded = trimmed.slice(separatorIndex + 2).trim();
+    }
+
+    const sanitized = encoded.replace(/\s+/g, "");
+    const binary = atob(sanitized);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object") {
+      if (alias && (!parsed.profile || typeof parsed.profile !== "object")) {
+        parsed.profile = { code: alias };
+      } else if (alias) {
+        parsed.profile.code = alias;
+      }
+      return { snapshot: parsed, code: alias };
+    }
+  } catch (error) {
+    console.error("No se pudo decodificar el código", error);
+  }
+  return null;
+}
+
+function updateSessionInfo() {
+  if (!sessionInfoSection) return;
+
+  if (!state.profile?.name) {
+    sessionInfoSection.classList.add("hidden");
+    return;
+  }
+
+  sessionInfoSection.classList.remove("hidden");
+  sessionGreeting.textContent = `¡Hola, ${state.profile.name}!`;
+  sessionDeviceLabel.textContent =
+    state.profile.device === "mobile"
+      ? "Estás usando la versión adaptada para celular."
+      : "Estás usando la versión adaptada para computadora.";
+  const themeName = state.selectedTheme?.name || "Tema personalizado";
+  sessionThemeLabel.textContent = `Tu estilo actual: ${themeName}`;
+  if (sessionCodeDisplay) {
+    sessionCodeDisplay.textContent = state.profile.code
+      ? `Tu alias de calendario: ${state.profile.code}`
+      : "";
+  }
+
+  const code = generateSyncCode();
+  syncCodeElement.textContent = code;
+  if (copySyncButton) {
+    copySyncButton.disabled = !code;
+  }
+}
+
+function updateThemeLockUI() {
+  if (state.themeLocked) {
+    heroSection?.classList.add("collapsed");
+    preferencesSection?.classList.add("collapsed");
+    suggestionsSection?.classList.add("collapsed");
+    suggestionList.innerHTML = "";
+    if (emptyState) {
+      emptyState.textContent = "";
+      emptyState.classList.remove("error", "loading");
+    }
+  } else {
+    heroSection?.classList.remove("collapsed");
+    preferencesSection?.classList.remove("collapsed");
+    suggestionsSection?.classList.remove("collapsed");
+    if (emptyState) {
+      updateStatus("Ingresá tus preferencias para ver propuestas.");
+    }
+  }
+}
+
+function handleCopySyncCode() {
+  if (!syncCodeElement) return;
+  const code = syncCodeElement.textContent.trim();
+  if (!code) {
+    showSyncFeedback("Todavía no hay nada para copiar.");
+    return;
+  }
+
+  const copyPromise = navigator.clipboard
+    ? navigator.clipboard.writeText(code)
+    : fallbackCopyText();
+
+  Promise.resolve(copyPromise)
+    .then(() => {
+      showSyncFeedback("Código copiado.");
+    })
+    .catch(() => {
+      showSyncFeedback("No se pudo copiar automáticamente. Copialo manualmente.");
+    });
+}
+
+function fallbackCopyText() {
+  const range = document.createRange();
+  range.selectNodeContents(syncCodeElement);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  try {
+    document.execCommand("copy");
+    selection.removeAllRanges();
+    return Promise.resolve();
+  } catch (error) {
+    selection.removeAllRanges();
+    return Promise.reject(error);
+  }
+}
+
+function showSyncFeedback(message) {
+  if (!syncFeedback) return;
+  syncFeedback.textContent = message;
+  if (syncFeedbackTimeout) {
+    clearTimeout(syncFeedbackTimeout);
+  }
+  if (message) {
+    syncFeedbackTimeout = window.setTimeout(() => {
+      syncFeedback.textContent = "";
+    }, 3000);
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1098,8 +1098,8 @@ function initializeSession() {
   populateNameSuggestions(users);
 
   const lastUser = localStorage.getItem(LAST_USER_KEY);
-  const defaultDevice = detectDefaultDevice();
   const stored = lastUser ? users[normalizeName(lastUser)] : null;
+  const initialDevice = resolvePreferredDevice(stored?.profile?.device);
 
   if (sessionNameInput) {
     if (stored?.name) {
@@ -1115,8 +1115,8 @@ function initializeSession() {
     sessionCodeInput.value = stored?.profile?.code || "";
   }
 
-  selectDeviceRadio(stored?.profile?.device || defaultDevice);
-  applyDeviceClass(stored?.profile?.device || defaultDevice);
+  selectDeviceRadio(initialDevice);
+  applyDeviceClass(initialDevice);
   showSessionScreen(Boolean(lastUser));
 }
 
@@ -1199,7 +1199,9 @@ function handleNameInputChange() {
   const users = getStoredUsers();
   const record = users[normalizeName(value)];
   if (record?.profile?.device) {
-    selectDeviceRadio(record.profile.device);
+    selectDeviceRadio(resolvePreferredDevice(record.profile.device));
+  } else {
+    selectDeviceRadio(resolvePreferredDevice());
   }
 }
 
@@ -1226,12 +1228,13 @@ function showSessionScreen(prefillCurrent = false) {
 
   if (prefillCurrent && state.profile?.name && sessionNameInput) {
     sessionNameInput.value = state.profile.name;
-    selectDeviceRadio(state.profile.device || detectDefaultDevice());
+    const preferredDevice = resolvePreferredDevice(state.profile.device);
+    selectDeviceRadio(preferredDevice);
     if (sessionCodeInput) {
       sessionCodeInput.value = state.profile.code || "";
     }
   } else if (sessionNameInput && !sessionNameInput.value) {
-    selectDeviceRadio(detectDefaultDevice());
+    selectDeviceRadio(resolvePreferredDevice());
   }
 
   window.setTimeout(() => sessionNameInput?.focus(), 80);
@@ -1275,6 +1278,14 @@ function detectDefaultDevice() {
     return "desktop";
   }
   return window.matchMedia("(max-width: 768px)").matches ? "mobile" : "desktop";
+}
+
+function resolvePreferredDevice(storedDevice) {
+  const detected = detectDefaultDevice();
+  if (!storedDevice) {
+    return detected;
+  }
+  return storedDevice === detected ? storedDevice : detected;
 }
 
 function applyDeviceClass(device) {

--- a/script.js
+++ b/script.js
@@ -1203,6 +1203,10 @@ function handleNameInputChange() {
   } else {
     selectDeviceRadio(resolvePreferredDevice());
   }
+
+  if (sessionCodeInput && record?.profile?.code) {
+    sessionCodeInput.value = record.profile.code;
+  }
 }
 
 function hydrateStateFromSnapshot(snapshot) {

--- a/styles.css
+++ b/styles.css
@@ -479,6 +479,10 @@ input[type="time"]:focus {
   transition: background 200ms ease, color 200ms ease;
 }
 
+body.device-mobile .calendar {
+  padding: 1.25rem 0.75rem 1.75rem;
+}
+
 .calendar.hidden {
   display: none;
 }
@@ -520,6 +524,24 @@ input[type="time"]:focus {
   transform: translateY(-1px);
   background: var(--accent-color);
   color: white;
+}
+
+.calendar-grid-wrapper {
+  width: 100%;
+  scrollbar-width: thin;
+}
+
+.calendar-grid-wrapper::-webkit-scrollbar {
+  height: 8px;
+}
+
+.calendar-grid-wrapper::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.18);
+  border-radius: 999px;
+}
+
+.calendar-grid-wrapper::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .calendar-grid {
@@ -665,6 +687,38 @@ input[type="time"]:focus {
 .calendar-cell .day-reset-button:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.8);
   outline-offset: 2px;
+}
+
+body.device-mobile .calendar-grid-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.75rem;
+  margin-inline: -0.5rem;
+  padding-inline: 0.5rem;
+}
+
+body.device-mobile .calendar-grid {
+  min-width: 560px;
+  grid-template-columns: repeat(7, minmax(80px, 1fr));
+  gap: 0.65rem;
+}
+
+body.device-mobile .calendar-cell {
+  min-height: 110px;
+  padding: 1rem;
+  padding-bottom: 2.5rem;
+  border-radius: 20px;
+}
+
+body.device-mobile .calendar-cell .events-container {
+  font-size: 0.95rem;
+  gap: 0.45rem;
+}
+
+body.device-mobile .calendar-cell .day-number {
+  font-size: 1.05rem;
+  right: 1rem;
+  bottom: 0.85rem;
 }
 
 .event-chip {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,784 @@
+:root {
+  color-scheme: light;
+  --background-color: #f5f7fb;
+  --card-background: #ffffffcc;
+  --accent-color: #3d5af1;
+  --accent-color-strong: #1d3ad9;
+  --text-color: #1f2933;
+  --muted-text: #52606d;
+  --calendar-border: rgba(61, 90, 241, 0.15);
+  --highlight-color: rgba(61, 90, 241, 0.2);
+  --font-family: "Poppins", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hidden {
+  display: none !important;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: var(--background-color);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+body.device-mobile {
+  --app-max-width: 420px;
+}
+
+body.device-desktop {
+  --app-max-width: 1200px;
+}
+
+.collapsed {
+  display: none !important;
+}
+
+main.app {
+  max-width: var(--app-max-width, 1100px);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+body.device-mobile main.app {
+  padding: 1.5rem 1rem 3rem;
+}
+
+body.device-desktop main.app {
+  padding: 2.5rem 2rem 4rem;
+}
+
+.session-screen {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.75rem;
+  background: var(--background-color);
+  overflow-y: auto;
+}
+
+body.device-mobile .session-screen {
+  padding: 2.25rem 1.25rem;
+}
+
+body.device-desktop .session-screen {
+  padding: 3.5rem 1.75rem;
+}
+
+.session-card {
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 22px;
+  width: min(480px, 100%);
+  padding: 2.25rem 2rem 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: 0 28px 55px rgba(15, 23, 42, 0.28);
+}
+
+.session-card h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.session-card p {
+  margin: 0;
+  color: #334155;
+}
+
+.device-options {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  padding: 1rem 1.25rem 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(248, 250, 252, 0.95);
+}
+
+.device-options legend {
+  font-weight: 600;
+  padding: 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.device-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.device-options input[type="radio"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent-color);
+}
+
+.sync-label {
+  font-weight: 500;
+}
+
+.session-hint {
+  margin: -0.35rem 0 0.85rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.session-error {
+  min-height: 1.2rem;
+  margin: 0;
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.session-info {
+  transition: opacity 160ms ease;
+}
+
+.session-summary {
+  gap: 1rem;
+}
+
+.session-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.session-summary-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.session-device,
+.session-theme,
+.session-code-display {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.98rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--accent-color-strong);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.link-button:hover,
+.link-button:focus-visible {
+  color: var(--accent-color);
+}
+
+.sync-area {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sync-description {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.9rem;
+}
+
+.sync-code-box {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sync-code-box code {
+  flex: 1 1 220px;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  word-break: break-all;
+  line-height: 1.4;
+  color: #0f172a;
+}
+
+.sync-feedback {
+  min-height: 1.2rem;
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted-text);
+}
+
+body.device-mobile .sync-code-box {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body.device-mobile .secondary-button {
+  width: 100%;
+}
+
+.hero {
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin: 0;
+  font-weight: 600;
+}
+
+.hero p {
+  color: var(--muted-text);
+  margin: 0 auto;
+  max-width: 60ch;
+  font-size: 1.05rem;
+}
+
+.card {
+  background: var(--card-background);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+.preferences form {
+  display: grid;
+  gap: 1rem;
+}
+
+.preferences label {
+  font-weight: 500;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 120px;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(82, 96, 109, 0.2);
+  font: inherit;
+  color: #111827;
+  background: rgba(255, 255, 255, 0.95);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 4px rgba(61, 90, 241, 0.18);
+}
+
+textarea::placeholder {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+body.auto-dark textarea {
+  color: #111827;
+  background: rgba(255, 255, 255, 0.98);
+}
+
+body.auto-dark textarea::placeholder {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+input[type="text"],
+input[type="time"] {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(82, 96, 109, 0.2);
+  padding: 0.7rem 0.9rem;
+  font: inherit;
+  color: #111827;
+  background: rgba(255, 255, 255, 0.98);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+input[type="text"]:focus,
+input[type="time"]:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 4px rgba(61, 90, 241, 0.18);
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease,
+    color 120ms ease;
+}
+
+.primary-button {
+  align-self: start;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color-strong));
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 12px 22px rgba(61, 90, 241, 0.25);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(61, 90, 241, 0.35);
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  box-shadow: none;
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--accent-color-strong);
+  font-weight: 600;
+  border: 1px solid rgba(61, 90, 241, 0.2);
+  padding-inline: 1.1rem;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  background: var(--accent-color);
+  color: white;
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(61, 90, 241, 0.2);
+}
+
+.suggestions {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.suggestions h2 {
+  margin: 0;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--muted-text);
+}
+
+.empty-state.loading {
+  color: var(--accent-color-strong);
+  font-weight: 500;
+}
+
+.empty-state.error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.suggestion-list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.suggestion-card {
+  background: var(--card-background);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 1rem;
+}
+
+.suggestion-card.selected {
+  border-color: var(--accent-color);
+  box-shadow: 0 18px 32px rgba(61, 90, 241, 0.28);
+}
+
+.palette {
+  display: flex;
+  gap: 0.35rem;
+  height: 24px;
+}
+
+.palette span {
+  flex: 1;
+  border-radius: 999px;
+}
+
+.suggestion-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.suggestion-description {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.suggestion-explanation {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--accent-color-strong);
+  font-weight: 500;
+}
+
+.generated-theme {
+  border: 1px solid var(--accent-color);
+  box-shadow: 0 18px 32px rgba(61, 90, 241, 0.28);
+}
+
+.calendar-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.calendar {
+  background: var(--card-background);
+  border-radius: 24px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.5rem;
+  transition: background 200ms ease, color 200ms ease;
+}
+
+.calendar.hidden {
+  display: none;
+}
+
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.calendar-month {
+  font-size: 1.5rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.calendar-theme {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.nav-button {
+  border: none;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--accent-color-strong);
+  border-radius: 999px;
+  width: 44px;
+  height: 44px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.nav-button:hover,
+.nav-button:focus-visible {
+  transform: translateY(-1px);
+  background: var(--accent-color);
+  color: white;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.calendar-cell {
+  aspect-ratio: 1;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--calendar-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: 0.75rem;
+  padding-bottom: 1.9rem;
+  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.08);
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+  overflow: hidden;
+}
+
+.calendar-cell.header {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  font-size: 0.85rem;
+  color: var(--muted-text);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  position: static;
+  padding: 0;
+}
+
+.calendar-cell.empty {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  position: static;
+}
+
+.calendar-cell.day-cell {
+  cursor: pointer;
+}
+
+.calendar-cell.day-cell:hover,
+.calendar-cell.day-cell:focus-visible {
+  border-color: var(--accent-color);
+  box-shadow: 0 16px 26px rgba(61, 90, 241, 0.25);
+  transform: translateY(-2px);
+}
+
+.calendar-cell.today {
+  border: 2px solid var(--accent-color);
+  box-shadow: 0 0 0 4px var(--highlight-color);
+}
+
+.calendar-cell .day-number {
+  position: absolute;
+  bottom: 0.65rem;
+  right: 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0f172a;
+  z-index: 3;
+}
+
+.calendar-cell.today .day-number {
+  color: #0f172a;
+}
+
+.calendar-cell .events-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  text-align: center;
+  color: #0f172a;
+  width: 100%;
+  min-height: 1.5rem;
+  position: relative;
+  z-index: 3;
+}
+
+.calendar-cell.past-day::before {
+  content: "";
+  position: absolute;
+  inset: 0.6rem;
+  background:
+    linear-gradient(
+      45deg,
+      transparent calc(50% - 2px),
+      rgba(220, 38, 38, 0.4) calc(50% - 2px),
+      rgba(220, 38, 38, 0.4) calc(50% + 2px),
+      transparent calc(50% + 2px)
+    ),
+    linear-gradient(
+      -45deg,
+      transparent calc(50% - 2px),
+      rgba(220, 38, 38, 0.4) calc(50% - 2px),
+      rgba(220, 38, 38, 0.4) calc(50% + 2px),
+      transparent calc(50% + 2px)
+    );
+  border-radius: 12px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.calendar-cell .day-reset-button {
+  position: absolute;
+  top: 0.55rem;
+  left: 0.55rem;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 8px;
+  border: none;
+  background: linear-gradient(135deg, #f87171, #dc2626);
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(220, 38, 38, 0.25);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  z-index: 4;
+}
+
+.calendar-cell .day-reset-button .reset-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.calendar-cell .day-reset-button:hover,
+.calendar-cell .day-reset-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(220, 38, 38, 0.3);
+}
+
+.calendar-cell .day-reset-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.event-chip {
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
+  padding: 0.35rem 0.55rem;
+  width: 100%;
+  max-width: 100%;
+  display: grid;
+  gap: 0.1rem;
+}
+
+.event-chip strong {
+  font-size: 0.78rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.event-chip span {
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.82);
+}
+
+@media (max-width: 768px) {
+  main.app {
+    padding-inline: 1rem;
+  }
+
+  .calendar {
+    padding: 1.25rem;
+  }
+
+  .calendar-grid {
+    gap: 0.35rem;
+  }
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 22px;
+  padding: 2.1rem 2rem 2.25rem;
+  width: min(420px, 100%);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: rgba(15, 23, 42, 0.7);
+  transition: color 120ms ease, transform 120ms ease;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  color: var(--accent-color-strong);
+  transform: scale(1.05);
+}
+
+.event-date-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.modal-form {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.modal-form label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.modal .primary-button {
+  justify-self: start;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.auto-dark {
+    --background-color: #0f172a;
+    --card-background: rgba(15, 23, 42, 0.78);
+    --accent-color: #38bdf8;
+    --accent-color-strong: #0ea5e9;
+    --text-color: #e2e8f0;
+    --muted-text: #94a3b8;
+    --calendar-border: rgba(56, 189, 248, 0.25);
+    --highlight-color: rgba(56, 189, 248, 0.18);
+  }
+}


### PR DESCRIPTION
## Summary
- reemplazar la superposición inicial por una pantalla de ingreso dedicada donde se elige el dispositivo y un código personal antes de abrir el calendario
- validar y persistir el alias elegido, generando códigos compartibles en formato `alias::datos` y mostrándolo en el panel de sesión junto con la opción para copiarlo
- actualizar la documentación para explicar el nuevo flujo de inicio y la forma de restaurar sesiones mediante el código personalizado

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf8f293710833293fd3c30ab399c2f